### PR TITLE
fixed console errors

### DIFF
--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -28,7 +28,7 @@ const Carousel = ({ cartItems, setCartItems }) => {
         carouselBooks.map((book, i) => {
           return (
             <div className="carousel" key={`${i}-carousel`}>
-              <div className="carousel--image" key={i}>
+              <div className="carousel--image" key={`${i}-carousel--image`}>
                 <img
                   src={book?.thumbnail}
                   height="350px"
@@ -36,7 +36,7 @@ const Carousel = ({ cartItems, setCartItems }) => {
                   alt=""
                 />
               </div>
-              <div key={i} className="carousel--text">
+              <div key={`${i}-carousel--text`} className="carousel--text">
                 <span>
                   <h1>{book?.title}</h1>
                 </span>


### PR DESCRIPTION
below error no longer displays in console:

Warning: Encountered two children with the same key, 0. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
